### PR TITLE
Fix PHP 8.4 deprecation issues

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -18,7 +18,7 @@
     },
     "minimum-stability": "dev",
     "require": {
-        "php": "^7.4|^8.0",
+        "php": "^7.4|^8.0|^8.4",
         "marshmallow/sluggable": "^1.0",
         "marshmallow/dataset-country": "^1.2",
         "marshmallow/commands": "^1.0"

--- a/src/Nova/Address.php
+++ b/src/Nova/Address.php
@@ -5,7 +5,6 @@ namespace Marshmallow\Addressable\Nova;
 use App\Nova\Resource;
 use Illuminate\Http\Request;
 use Laravel\Nova\Fields\Text;
-use Laravel\Nova\Fields\Place;
 use Laravel\Nova\Fields\MorphTo;
 use Laravel\Nova\Fields\BelongsTo;
 use Marshmallow\Addressable\Addresses;
@@ -51,7 +50,7 @@ class Address extends Resource
             Text::make(__('Name'))->help(
                 __('This can be used as a reference for this address. For instance this could say: "Home" or "Office"')
             ),
-            Place::make(__('Address'), 'address_line_1'),
+            Text::make(__('Address'), 'address_line_1'),
             Text::make(__('Address Line 2'), 'address_line_2')->hideFromIndex(),
             Text::make(__('City'), 'city'),
             Text::make(__('State'), 'state')->hideFromIndex(),

--- a/src/Policies/AddressPolicy.php
+++ b/src/Policies/AddressPolicy.php
@@ -2,9 +2,9 @@
 
 namespace Marshmallow\Addressable\Policies;
 
-use App\User;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Auth\Access\HandlesAuthorization;
+use Illuminate\Contracts\Auth\Authenticatable;
 
 class AddressPolicy
 {
@@ -13,10 +13,10 @@ class AddressPolicy
     /**
      * Determine whether the user can view any support tickets.
      *
-     * @param  \App\User  $user
+     * @param  \Illuminate\Contracts\Auth\Authenticatable  $user
      * @return mixed
      */
-    public function viewAny(User $user)
+    public function viewAny(Authenticatable $user)
     {
         return true;
     }
@@ -24,11 +24,11 @@ class AddressPolicy
     /**
      * Determine whether the user can view the support ticket.
      *
-     * @param  \App\User  $user
+     * @param  \Illuminate\Contracts\Auth\Authenticatable  $user
      * @param  \Illuminate\Database\Eloquent\Model  $model
      * @return mixed
      */
-    public function view(User $user, Model $model)
+    public function view(Authenticatable $user, Model $model)
     {
         return true;
     }
@@ -36,10 +36,10 @@ class AddressPolicy
     /**
      * Determine whether the user can create support tickets.
      *
-     * @param  \App\User  $user
+     * @param  \Illuminate\Contracts\Auth\Authenticatable  $user
      * @return mixed
      */
-    public function create(User $user)
+    public function create(Authenticatable $user)
     {
         return true;
     }
@@ -47,11 +47,11 @@ class AddressPolicy
     /**
      * Determine whether the user can update the support ticket.
      *
-     * @param  \App\User  $user
+     * @param  \Illuminate\Contracts\Auth\Authenticatable  $user
      * @param  \Illuminate\Database\Eloquent\Model  $model
      * @return mixed
      */
-    public function update(User $user, Model $model)
+    public function update(Authenticatable $user, Model $model)
     {
         return true;
     }
@@ -59,11 +59,11 @@ class AddressPolicy
     /**
      * Determine whether the user can delete the support ticket.
      *
-     * @param  \App\User  $user
+     * @param  \Illuminate\Contracts\Auth\Authenticatable  $user
      * @param  \Illuminate\Database\Eloquent\Model  $model
      * @return mixed
      */
-    public function delete(User $user, Model $model)
+    public function delete(Authenticatable $user, Model $model)
     {
         return true;
     }
@@ -71,11 +71,11 @@ class AddressPolicy
     /**
      * Determine whether the user can restore the support ticket.
      *
-     * @param  \App\User  $user
+     * @param  \Illuminate\Contracts\Auth\Authenticatable  $user
      * @param  \Illuminate\Database\Eloquent\Model  $model
      * @return mixed
      */
-    public function restore(User $user, Model $model)
+    public function restore(Authenticatable $user, Model $model)
     {
         return true;
     }
@@ -83,11 +83,11 @@ class AddressPolicy
     /**
      * Determine whether the user can permanently delete the support ticket.
      *
-     * @param  \App\User  $user
+     * @param  \Illuminate\Contracts\Auth\Authenticatable  $user
      * @param  \Illuminate\Database\Eloquent\Model  $model
      * @return mixed
      */
-    public function forceDelete(User $user, Model $model)
+    public function forceDelete(Authenticatable $user, Model $model)
     {
         return true;
     }

--- a/src/Rules/AddressRule.php
+++ b/src/Rules/AddressRule.php
@@ -2,12 +2,11 @@
 
 namespace Marshmallow\Addressable\Rules;
 
-use Illuminate\Contracts\Validation\Rule;
+use Illuminate\Contracts\Validation\ValidationRule;
+use Closure;
 
-class AddressRule implements Rule
+class AddressRule implements ValidationRule
 {
-    protected $message;
-
     /**
      * Create a new rule instance.
      *
@@ -19,24 +18,16 @@ class AddressRule implements Rule
     }
 
     /**
-     * Determine if the validation rule passes.
+     * Run the validation rule.
      *
      * @param  string  $attribute
      * @param  mixed  $value
-     * @return bool
+     * @param  \Closure  $fail
+     * @return void
      */
-    public function passes($attribute, $value)
+    public function validate(string $attribute, mixed $value, Closure $fail): void
     {
-        return true;
-    }
-
-    /**
-     * Get the validation error message.
-     *
-     * @return string
-     */
-    public function message()
-    {
-        return $this->message;
+        // Validation logic here - currently always passes
+        // If validation fails, call: $fail('Validation error message')
     }
 }


### PR DESCRIPTION
## Summary
- Replaced deprecated `Laravel\Nova\Fields\Place` with `Text` field in Nova Address resource
- Updated `AddressPolicy` to use `Authenticatable` interface instead of hardcoded `App\User` type
- Migrated `AddressRule` from deprecated `Rule` interface to new `ValidationRule` interface  
- Added PHP 8.4 support to composer.json requirements

## Fixes
- Resolves deprecated Place field usage in Nova resource
- Fixes invalid user type references in policy methods
- Updates validation rule to use modern Laravel interface
- Ensures compatibility with PHP 8.4

This addresses all deprecation warnings listed in issue #17.